### PR TITLE
Added README, REFINEMENT_TEMPLATE

### DIFF
--- a/BILLING_API_REFINEMENT_TEMPLATE.lkml
+++ b/BILLING_API_REFINEMENT_TEMPLATE.lkml
@@ -1,0 +1,95 @@
+include: "//azure-billing/**/*.view.lkml"
+include: "//azure-billing/**/*.explore.lkml"
+
+# Use LookML refinements to refine views and explores defined in the remote project.
+# Learn more at: https://docs.looker.com/data-modeling/learning-lookml/refinements
+
+# This Refinement Template demonstrates mapping of REST API GET Results to the corresponding
+#  fields that would have been generated if utilizing the Cost Management export.
+# This can be copied into the Marketplace Project's default Refinement File
+# (which resides in the installed project's root directory) and then revised as necessary.
+
+view: +azure_billing {
+
+  dimension: currency {
+    type: string
+    ## Currency = BillingCurrencyCode
+    ## sql: ${TABLE}.Currency ;;
+    sql: ${TABLE}.BillingCurrencyCode ;;
+  }
+
+  dimension: instance_id {
+    group_label: "IDs"
+    type: string
+    ## InstanceId = ResourceId
+    ## sql: ${TABLE}.InstanceId ;;
+    sql: ${TABLE}.ResourceId ;;
+  }
+
+  dimension: resource_rate {
+    group_label: "Resource"
+    type: string
+    ## ResourceRate = EffectivePrice
+    ## sql: ${TABLE}.ResourceRate ;;
+    sql: ${TABLE}.EffectivePrice ;;
+  }
+
+  dimension: resource_type {
+    group_label: "Resource"
+    type: string
+    ## ResourceType = ChargeType
+    ## sql: ${TABLE}.ResourceType ;;
+    sql: ${TABLE}.ChargeType ;;
+  }
+
+  dimension: subscription_guid {
+    group_label: "IDs"
+    type: string
+    ## SubscriptionGuid = SubscriptionId
+    ## sql: ${TABLE}.SubscriptionGuid ;;
+    sql: ${TABLE}.SubscriptionId ;;
+  }
+
+  dimension_group: usage_date_time {
+    label: "Usage"
+    type: time
+    ## UsageDateTime = BillingPeriodStartDate
+    ## sql: TIMESTAMP(${TABLE}.UsageDateTime) ;;
+    sql: TIMESTAMP(${TABLE}.BillingPeriodStartDate) ;;
+  }
+
+  dimension: pre_tax_cost {
+    hidden: yes
+    type: number
+    ## PreTaxCost = CostInBillingCurrency
+    sql: CAST(${TABLE}.CostInBillingCurrency  AS FLOAT64)*200 ;;
+  }
+
+  dimension: service_name {
+    group_label: "Service"
+    type: string
+    ## ServiceName = ProductName
+    sql: ${TABLE}.ProductName ;;
+  }
+
+  dimension: service_tier {
+    group_label: "Service"
+    type: string
+    ## ServiceTier = ServiceFamily
+    sql: ${TABLE}.ServiceFamily ;;
+  }
+
+  dimension: usage_quantity {
+    hidden: yes
+    type: string
+    ## UsageQuantity = Quantity
+    sql: ${TABLE}.quantity ;;
+  }
+
+  measure: total_usage_quantity {
+    type: sum
+    sql: ${usage_quantity} ;;
+    ## Changing Value Format Name
+    value_format_name: decimal_2
+  }
+}

--- a/README.MD
+++ b/README.MD
@@ -1,0 +1,19 @@
+# Cloud Cost Management: Azure
+
+Connect directly to your billing data in Azure to provide a consolidated reporting view of cloud spend.
+
+This Looker Block for Azure billing provides insights around usage of Azure services and the associated costs,
+and focuses on the three most common levers of cost-savings, including:
+- Increasing reserved instance coverage and utilization
+- Decreasing data transfer costs
+- Allocating costs over custom variable
+
+Whether you need the report segmented by product type, user identity, or region, this block's Explore and Dashboard can be cut-and-sliced any number of ways to properly allocate costs for any of your business needs.
+You can then drill into any specific line item to see even more detail, such as the selected operating system, tenancy, purchase option (on-demand, spot, or reserved), etc..
+
+## Installation Requirements
+* This block assumes a [Looker connection to Microsoft Azure Synapse Analytics](https://docs.looker.com/setup-and-management/database-config/ms-azure-sql-dw) is being used to retreive the Cost Management data residing on a Microsoft Azure SQL Warehouse.
+
+* This block leverages the [Azure Cost Management's default export schema](https://docs.microsoft.com/en-us/azure/cost-management-billing/costs/tutorial-export-acm-data?tabs=azure-portal). However, if you have extracted your data utilizing the [Azure Billing REST API](https://docs.microsoft.com/en-us/rest/api/billing/), this block will still be useful. In this scenario, a Refinement File will likely be required to ensure the field names on your exported data are matched to the expected dimensions defined in this block. Please see the included **"BILLING_API_REFINEMENT_TEMPLATE.LKML"** File within the block for an example template matching common API GET call results to the block dimensions.
+
+* For additional information on using refinements to customize marketplace blocks, please see [this documentation](https://docs.looker.com/data-modeling/marketplace/customize-blocks).


### PR DESCRIPTION
Added a README.MD File to the block. The content was largely sourced from the marketplace listing information, and revised to include Refinement steps that may be required.

A BILLING_API_REFINEMENT_TEMPLATE.LKML file was added. This file is not included in any models, and acts as a copy/paste-able template for users who install this block over data not extracted by the default Azure Cost Management export.